### PR TITLE
Enable compilation on GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(
+    ParkerWords
+    LANGUAGES C CXX
+    VERSION 0.1.0)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_executable(parker-words parkerwords.cpp)
+
+target_compile_features(parker-words PUBLIC cxx_std_20)
+target_compile_options(parker-words PUBLIC -mavx -mavx2)

--- a/parkerwords.cpp
+++ b/parkerwords.cpp
@@ -17,7 +17,11 @@
 #include <future>
 #include <condition_variable>
 #include <mutex>
+#ifdef __GNUC__
+#include <x86intrin.h>
+#else
 #include <intrin.h>
+#endif
 #include <emmintrin.h>
 
 constexpr int MaxThreads = 16;
@@ -97,7 +101,7 @@ void readwords(const char* file)
     in.seekg(0, std::ios::beg);
     in.read(&buf[0], chunksize);
 
-    volatile size_t nextChunk = chunksize;
+    std::atomic<size_t> nextChunk = chunksize;
 	auto doread = [&]()
 	{
 		in.read(&buf[nextChunk], chunksize);


### PR DESCRIPTION
Hi! this is a small change which enables compilation with GCC, and also fixes a warning where volatile was used instead of atomic